### PR TITLE
Added a new cmake_config_file corresponding to a working marconi m100 installation

### DIFF
--- a/cmake/machines/m100_gnu.json
+++ b/cmake/machines/m100_gnu.json
@@ -1,0 +1,12 @@
+{
+    "cmake_args": [
+           "-DCMAKE_C_COMPILER=mpicc",
+           "-DCMAKE_CXX_COMPILER=mpicxx",
+           "-DCMAKE_Fortran_COMPILER=mpifort",
+	   "-DCMAKE_MPI_HOME=/cineca/prod/opt/compilers/openmpi/4.1.2/gnu--8.4.0",
+           "-DNETCDF_INC_PATH=/cineca/prod/opt/libraries/netcdff/4.5.2/gnu--8.4.0/include",
+           "-DNETCDF_LIB_PATH=/cineca/prod/opt/libraries/netcdff/4.5.2/gnu--8.4.0/lib",
+           "-DBLA_VENDOR=OpenBLAS",
+	   "-DSCALAPACK_LIB_DIR=/cineca/prod/opt/libraries/scalapack/2.1.0/openmpi--4.0.3--gnu--8.4.0/lib"
+           ]
+}


### PR DESCRIPTION
This cmake_config_file was used to install VMEC2000 on Marconi M100 with the command
`python setup.py install --user`
The modules needed to load are the following:
`module load profile/global
module load gnu/8.4.0
module load openmpi/4.0.3--gnu--8.4.0
module load zlib/1.2.11--gnu--8.4.0
module load szip/2.1.1--gnu--8.4.0
module load hdf5/1.12.0--gnu--8.4.0
module load netcdf/4.7.3--gnu--8.4.0
module load netcdff/4.5.2--gnu--8.4.0
module load gsl/2.6--gnu--8.4.0
module load blas/3.8.0--gnu--8.4.0
module load openblas/0.3.9--gnu--8.4.0
module load lapack/3.9.0--gnu--8.4.0
module load scalapack/2.1.0--openmpi--4.0.3--gnu--8.4.0
module load git
module load python`