### PR TITLE
Fixed netcdf warnings.

### DIFF
--- a/Sources/Input_Output/wrout.f
+++ b/Sources/Input_Output/wrout.f
@@ -431,7 +431,7 @@
 
       CALL cdf_define(nwout, vn_qfact, qfact(1:ns), 
      1                dimname=r1dim)
-      CALL cdf_setatt(nwout, vn_iotaf, ln_qfact)
+      CALL cdf_setatt(nwout, vn_qfact, ln_qfact)
       CALL cdf_define(nwout, vn_presf, presf, 
      1                dimname=r1dim)
       CALL cdf_setatt(nwout, vn_presf, ln_presf, units='Pa')
@@ -1296,11 +1296,11 @@
       CALL cdf_write(nwout, vn_overr, overr(1:ns))
 
 !     MERCIER_CRITERION
-      CALL cdf_write(nwout, vn_merc, Dmerc)
-      CALL cdf_write(nwout, vn_mshear, Dshear)
-      CALL cdf_write(nwout, vn_mwell, Dwell)
-      CALL cdf_write(nwout, vn_mcurr, Dcurr)
-      CALL cdf_write(nwout, vn_mgeo, Dgeod)
+      CALL cdf_write(nwout, vn_merc, Dmerc(1:ns))
+      CALL cdf_write(nwout, vn_mshear, Dshear(1:ns))
+      CALL cdf_write(nwout, vn_mwell, Dwell(1:ns))
+      CALL cdf_write(nwout, vn_mcurr, Dcurr(1:ns))
+      CALL cdf_write(nwout, vn_mgeo, Dgeod(1:ns))
       CALL cdf_write(nwout, vn_equif, equif)
 
       CALL cdf_write(nwout, vn_fsq, fsqt(1:nstore_seq))

--- a/python/tests/test_regression.py
+++ b/python/tests/test_regression.py
@@ -4,7 +4,7 @@ import unittest
 import logging
 import os
 import numpy as np
-from scipy.io import netcdf
+from scipy.io import netcdf_file
 from mpi4py import MPI
 import vmec
 
@@ -127,12 +127,12 @@ class RegressionTests(unittest.TestCase):
 
                         ierr = 0
                         logger.info('About to read output file {}'.format(wout_file))
-                        f1 = netcdf.netcdf_file(wout_file, mmap=False)
+                        f1 = netcdf_file(wout_file, mmap=False)
                         #vmec.read_wout_mod.read_wout_file(wout_file, ierr)
                         #self.assertEqual(ierr, 0)
 
                         logger.info('About to read reference output file {}'.format(reference_file))
-                        f2 = netcdf.netcdf_file(reference_file, mmap=False)
+                        f2 = netcdf_file(reference_file, mmap=False)
 
                         compare(f1, f2, 'iotaf')
                         compare(f1, f2, 'rmnc')

--- a/python/tests/test_simple.py
+++ b/python/tests/test_simple.py
@@ -4,7 +4,7 @@ import unittest
 import os
 import logging
 import numpy as np
-from scipy.io import netcdf
+from scipy.io import netcdf_file
 from mpi4py import MPI
 import vmec
 
@@ -95,7 +95,7 @@ class SimpleTests(unittest.TestCase):
         #ierr = 0
         #vmec.read_wout_mod.read_wout_file(wout_file, ierr)
         #self.assertEqual(ierr, 0)
-        f = netcdf.netcdf_file(wout_file, mmap=False)
+        f = netcdf_file(wout_file, mmap=False)
         
         #self.assertAlmostEqual(vmec.read_wout_mod.betatot, \
         self.assertAlmostEqual(f.variables['betatotal'][()], \


### PR DESCRIPTION
This PR fixes error messages that were being printed whenever VMEC runs:
~~~~
% cdfPurVar_1d--E-- A netCDF error has occurred in: nf_put_var_double
while processing: DMerc
 NetCDF: Start+count exceeds dimension bound                                    
 
% cdfPurVar_1d--E-- A netCDF error has occurred in: nf_put_var_double
while processing: DShear
 NetCDF: Start+count exceeds dimension bound                                    
 
% cdfPurVar_1d--E-- A netCDF error has occurred in: nf_put_var_double
while processing: DWell
 NetCDF: Start+count exceeds dimension bound                                    
 
% cdfPurVar_1d--E-- A netCDF error has occurred in: nf_put_var_double
while processing: DCurr
 NetCDF: Start+count exceeds dimension bound                                    
 
% cdfPurVar_1d--E-- A netCDF error has occurred in: nf_put_var_double
while processing: DGeod
 NetCDF: Start+count exceeds dimension bound 
~~~~
Also, the tests were updated to use `scipy.io.netcdf_file` instead of `scipy.io.netcdf.netcdf_file`, consistent with the latter being deprecated in `scipy`. Finally, a typo `vn_qfact` -> `vn_iotaf` was fixed, matching a fix in the stellopt version of vmec.