### PR TITLE
Suppress warnings for free boundary

### DIFF
--- a/Sources/NESTOR_vacuum/fouri.f
+++ b/Sources/NESTOR_vacuum/fouri.f
@@ -103,7 +103,7 @@ C-----------------------------------------------
 
       IF (vlactive) THEN
          CALL second0(ton)
-         print*,"WARNING: MPI_IN_PLACE in fouri.f"  ! MJL
+         !print*,"WARNING: MPI_IN_PLACE in fouri.f"  ! MJL
          CALL MPI_Allreduce(MPI_IN_PLACE, amatrix, SIZE(amatrix),
      &                      MPI_REAL8, MPI_SUM, VAC_COMM, MPI_ERR)
          CALL second0(toff)

--- a/Sources/NESTOR_vacuum/scalpot.f
+++ b/Sources/NESTOR_vacuum/scalpot.f
@@ -95,7 +95,7 @@ C-----------------------------------------------
 
          CALL second0(ton)
          IF (vlactive) THEN
-            print*,"WARNING: MPI_IN_PLACE in scalpot.f 1"  ! MJL
+            !print*,"WARNING: MPI_IN_PLACE in scalpot.f 1"  ! MJL
             CALL MPI_Allreduce(MPI_IN_PLACE, gstore, SIZE(gstore),
      &                         MPI_REAL8, MPI_SUM, VAC_COMM, MPI_ERR)
          END IF
@@ -121,7 +121,7 @@ C-----------------------------------------------
 !
       CALL second0(ton)
       IF (vlactive) THEN
-            print*,"WARNING: MPI_IN_PLACE in scalpot.f 2"  ! MJL
+            !print*,"WARNING: MPI_IN_PLACE in scalpot.f 2"  ! MJL
          CALL MPI_Allreduce(MPI_IN_PLACE, bvec, SIZE(bvec), MPI_REAL8,
      &                      MPI_SUM, VAC_COMM, MPI_ERR)
       END IF

--- a/Sources/NESTOR_vacuum/vacuum.f
+++ b/Sources/NESTOR_vacuum/vacuum.f
@@ -234,7 +234,7 @@ C-----------------------------------------------
       CALL second0(ton)
 
       IF (vlactive) THEN
-         print *,"WARNING: MPI_IN_PLACE in vacuum.f"  ! MJL
+         !print *,"WARNING: MPI_IN_PLACE in vacuum.f"  ! MJL
          CALL MPI_Allgatherv(MPI_IN_PLACE, numjs_vac, MPI_REAL8, bsqvac,
      &                       counts_vac, disps_vac, MPI_REAL8, VAC_COMM,
      &                       MPI_ERR)


### PR DESCRIPTION
Previously I had inserted some warnings when MPI_IN_PLACE was used, related to debugging an MPI issue on IPP Cobra. These warnings only appeared for free-boundary calculations, so they did not appear in simsopt tests. But a few people are using free-boundary now so these warnings fill the screen. Therefore here I'm removing them. 