### PR TITLE
Update for numpy 2

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -12,7 +12,7 @@ jobs:
       matrix:
         # If os = macos-latest, the extension builds ok, but there is a seg fault when trying to use it.
         os: [ubuntu-latest]
-        python-version: [3.7, 3.8, 3.9]
+        python-version: [3.8, 3.9, 3.10, 3.11]
         use-pip: [yes-pip, no-pip]
 
     runs-on: ${{ matrix.os }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -12,7 +12,7 @@ jobs:
       matrix:
         # If os = macos-latest, the extension builds ok, but there is a seg fault when trying to use it.
         os: [ubuntu-latest]
-        python-version: [3.8, 3.9, 3.10, 3.11]
+        python-version: ["3.8", "3.9", "3.10", "3.11"]
         use-pip: [yes-pip, no-pip]
 
     runs-on: ${{ matrix.os }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -95,7 +95,7 @@ jobs:
       if: "contains(matrix.use-pip, 'no-pip')"
       run: |
         pip install wheel scikit-build ninja
-        pip install git+https://github.com/jameskermode/f90wrap
+        pip install f90wrap
      
     - name: List installed python packages
       run: pip list

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -93,7 +93,9 @@ jobs:
     - name: Install more python packages
       # If using 'pip install', these packages should be included automatically.
       if: "contains(matrix.use-pip, 'no-pip')"
-      run: pip install wheel scikit-build ninja f90wrap
+      run: |
+        pip install wheel scikit-build ninja
+        pip install git+https://github.com/jameskermode/f90wrap
      
     - name: List installed python packages
       run: pip list

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -12,7 +12,7 @@ jobs:
       matrix:
         # If os = macos-latest, the extension builds ok, but there is a seg fault when trying to use it.
         os: [ubuntu-latest]
-        python-version: ["3.8", "3.9", "3.10", "3.11", "3.12"]
+        python-version: ["3.8", "3.9", "3.10", "3.11"]
         use-pip: [yes-pip, no-pip]
 
     runs-on: ${{ matrix.os }}

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -37,7 +37,7 @@ jobs:
       run: |
         sudo -H -E $pythonLocation/bin/python -m pip install --upgrade pip
         sudo -H -E $pythonLocation/bin/python -m pip install numpy mpi4py 
-        sudo -H -E $pythonLocation/bin/python -m pip install wheel scikit-build ninja git+https://github.com/jameskermode/f90wrap
+        sudo -H -E $pythonLocation/bin/python -m pip install wheel scikit-build ninja f90wrap
 
     - name: Install simsopt package
       run: | 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,2 +1,2 @@
 [build-system]
-requires = ["setuptools", "wheel", "scikit-build", "cmake",  "ninja", "numpy", "f90wrap"]
+requires = ["setuptools", "wheel", "scikit-build", "cmake",  "ninja", "numpy", "f90wrap @ git+https://github.com/jameskermode/f90wrap"]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,2 +1,2 @@
 [build-system]
-requires = ["setuptools", "wheel", "scikit-build", "cmake",  "ninja", "numpy>=2.0.0", "f90wrap@git+https://github.com/jameskermode/f90wrap"]
+requires = ["setuptools", "wheel", "scikit-build", "cmake",  "ninja", "numpy>=2.0.0", "f90wrap"]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -5,7 +5,7 @@ requires = [
   "scikit-build",
   "cmake",
   "ninja",
-  "numpy>=2.0.0; python_version > 3.8",
-  "numpy<2.0.0; python_version <= 3.8",
+  "numpy>=2.0.0; python_version > '3.8'",
+  "numpy<2.0.0; python_version <= '3.8'",
   "f90wrap"
 ]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,2 +1,11 @@
 [build-system]
-requires = ["setuptools", "wheel", "scikit-build", "cmake",  "ninja", "numpy>=2.0.0", "f90wrap"]
+requires = [
+  "setuptools",
+  "wheel",
+  "scikit-build",
+  "cmake",
+  "ninja",
+  "numpy>=2.0.0; python_version > 3.8",
+  "numpy<2.0.0; python_version <= 3.8",
+  "f90wrap"
+]

--- a/setup.py
+++ b/setup.py
@@ -33,7 +33,7 @@ setup(
     url="https://github.com/hiddenSymmetries/VMEC2000",
     packages=['vmec'],
     package_dir={'': 'python'},
-    install_requires=['f90wrap @ git+https://github.com/jameskermode/f90wrap'],
+    install_requires=['f90wrap'],
     python_requires=">=3.8",
     ext_modules=EmptyListWithLength(),
     description="Python wrapper for VMEC2000",

--- a/setup.py
+++ b/setup.py
@@ -33,7 +33,7 @@ setup(
     url="https://github.com/hiddenSymmetries/VMEC2000",
     packages=['vmec'],
     package_dir={'': 'python'},
-    install_requires=['f90wrap'],
+    install_requires=['f90wrap @ git+https://github.com/jameskermode/f90wrap'],
     python_requires=">=3.6",
     ext_modules=EmptyListWithLength(),
     description="Python wrapper for VMEC2000",


### PR DESCRIPTION
When numpy 2.0.0 was released the other day, it starting causing errors in the CI for simsopt related to f90wrap and installing VMEC2000. An update to f90wrap was just merged for compatibility with the new numpy release. There has not been a new f90wrap version on pypi, not sure how log that will take, might depend on Caoxiang's PR there. In this PR, vmec2000 specifies the dev version of f90wrap instead of the pypi version to get the new numpy 2 compatibility. With this change, the VMEC2000 CI now passes, so I think simsopt's would as well. Do we want to make this change here in vmec2000, so we can get other workflows like simsopt running again, or just wait until f90wrap makes another release?