### PR TITLE
fix setuptools version to lt.65

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [build-system]
 requires = [
-  "setuptools",
+  "setuptools<65",
   "wheel",
   "scikit-build",
   "cmake",


### PR DESCRIPTION
fixing setuptools as it could be the cause for failure to compile. 

My guess is it's due to a confluence of version resolution changes precipitated by numpy2.0, causing our cointainers to have a newer version of setuptools, which has a bug that looks for this compiler, but fails. 

Fixing it below version 65 should help, this PR is a test, currently running simsopt targeting this branch so do not merge yet. 